### PR TITLE
fix(): use kestrel to run API component

### DIFF
--- a/AppointmentApi/Program.cs
+++ b/AppointmentApi/Program.cs
@@ -20,6 +20,7 @@ namespace AppointmentApi
             Host.CreateDefaultBuilder(args)
                 .ConfigureWebHostDefaults(webBuilder =>
                 {
+                    webBuilder.UseKestrel();
                     webBuilder.UseStartup<Startup>();
                 });
     }


### PR DESCRIPTION
Use Kestrel for both API and Razor components to ensure full compatibility.