### PR TITLE
Fix session cookies not working properly with users

### DIFF
--- a/AppointmentRazor/Startup.cs
+++ b/AppointmentRazor/Startup.cs
@@ -37,7 +37,10 @@ namespace AppointmentRazor
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
-            services.AddSession();
+            services.AddSession(opts =>
+            {
+                opts.Cookie.IsEssential = true;
+            });
 
             services.Configure<CookiePolicyOptions>(options =>
             {


### PR DESCRIPTION
Fix session cookies not working properly with users due to redefined cookies policies since .NET Core 2.1. More info: https://andrewlock.net/session-state-gdpr-and-non-essential-cookies/
